### PR TITLE
Deprecates the Covid Tracking Project

### DIFF
--- a/covid_block/covid_tracking_project.view.lkml
+++ b/covid_block/covid_tracking_project.view.lkml
@@ -185,7 +185,7 @@ view: covid_tracking_project_core {
 ## Based on new_vs_running_total parameter chosen, return new or running total hospitalizations
   measure: hospitalizations {
     group_label: "Dynamic (Testing - US Only)"
-    description: "Use with New vs Running Total Filter, can be useful for creating a Look or Dashboard where you toggle between the two"
+    description: "Use with New vs Running Total Filter, can be useful for creating a Look or Dashboard where you toggle between the two  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     label: "Hospitalizations"
     type: number
     hidden: yes
@@ -261,7 +261,7 @@ view: covid_tracking_project_core {
 ## Based on new_vs_running_total parameter chosen, return new or running total of tests
   measure: total {
     group_label: "Dynamic (Testing - US Only)"
-    description: "Use with New vs Running Total Filter, can be useful for creating a Look or Dashboard where you toggle between the two"
+    description: "Use with New vs Running Total Filter, can be useful for creating a Look or Dashboard where you toggle between the two  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     label: "Total Tests"
     type: number
     hidden: yes
@@ -279,7 +279,7 @@ view: covid_tracking_project_core {
 
   measure: hospitalized_new {
     group_label: "New Cases (Testing - US Only)"
-    description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used"
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     label: "Hospitalizations"
     hidden: yes
     type: sum
@@ -311,7 +311,7 @@ view: covid_tracking_project_core {
   measure: hospitalized_running_total {
     group_label: "Running Total (Testing - US Only)"
     label: "Hospitalizations (Running Total)"
-    description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used."
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used.  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     type: number
     hidden: yes
     sql:
@@ -472,7 +472,7 @@ view: covid_tracking_project_core {
   measure: total_new {
     group_label: "New Cases (Testing - US Only)"
     label: "Total Tests (New)"
-    description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used "
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     type: sum
     hidden: yes
     sql: ${total_new_cases} ;;
@@ -502,7 +502,7 @@ view: covid_tracking_project_core {
 ## If date in query, show running total of total tests for given date(s), otherwise show running total of total test results for most recent date
   measure: total_running_total {
     group_label: "Running Total (Testing - US Only)"
-    description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used."
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used.  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     label: "Total Tests (Running Total)"
     type: number
     hidden: yes
@@ -561,7 +561,7 @@ view: covid_tracking_project_core {
 
   measure: case_hospitalization_rate {
     group_label: "Rates (Testing - US Only)"
-    description: "What percent of infections have resulted in hospitalization?"
+    description: "What percent of infections have resulted in hospitalization?  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     type: number
     hidden: yes
     sql: 1.0 * ${hospitalized_running_total}/NULLIF(${positive_running_total}, 0);;
@@ -657,7 +657,7 @@ view: covid_tracking_project_core {
   measure: case_fatality_rate {
     hidden: yes
     group_label: "Rates (Testing - US Only)"
-    description: "What percent of infections have resulted in death?"
+    description: "What percent of infections have resulted in death?  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     type: number
     sql: 1.0 * ${death_running_total}/NULLIF(${positive_running_total}, 0);;
     value_format_name: percent_1
@@ -671,7 +671,7 @@ view: covid_tracking_project_core {
   measure: case_fatality_or_hospitalization_rate {
     hidden: yes
     group_label: "Rates (Testing - US Only)"
-    description: "What percent of infections have resulted in hospitalization or death?"
+    description: "What percent of infections have resulted in hospitalization or death?  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     type: number
     sql: 1.0 * (${death_running_total} + ${hospitalized_running_total}) /NULLIF(${positive_running_total}, 0);;
     value_format_name: percent_1

--- a/covid_block/covid_tracking_project.view.lkml
+++ b/covid_block/covid_tracking_project.view.lkml
@@ -188,6 +188,7 @@ view: covid_tracking_project_core {
     description: "Use with New vs Running Total Filter, can be useful for creating a Look or Dashboard where you toggle between the two"
     label: "Hospitalizations"
     type: number
+    hidden: yes
     sql:
         {% if covid_combined.new_vs_running_total._parameter_value == 'new_cases' %} ${hospitalized_new}
         {% elsif covid_combined.new_vs_running_total._parameter_value == 'running_total' %} ${hospitalized_running_total}
@@ -203,8 +204,9 @@ view: covid_tracking_project_core {
 ## Based on new_vs_running_total parameter chosen, return new or running total negative test results
   measure: negative_test {
     group_label: "Dynamic (Testing - US Only)"
-    description: "Use with New vs Running Total Filter, can be useful for creating a Look or Dashboard where you toggle between the two"
+    description: "Use with New vs Running Total Filter, can be useful for creating a Look or Dashboard where you toggle between the two **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     label: "Negative Test Results"
+    hidden: yes
     type: number
     sql:
         {% if covid_combined.new_vs_running_total._parameter_value == 'new_cases' %} ${negative_new}
@@ -221,8 +223,9 @@ view: covid_tracking_project_core {
 ## Based on new_vs_running_total parameter chosen, return new or running total pending test results
   measure: pending_test {
     group_label: "Dynamic (Testing - US Only)"
-    description: "Use with New vs Running Total Filter, can be useful for creating a Look or Dashboard where you toggle between the two"
+    description: "Use with New vs Running Total Filter, can be useful for creating a Look or Dashboard where you toggle between the two. **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     label: "Pending Test Results"
+    hidden: yes
     type: number
     sql:
         {% if covid_combined.new_vs_running_total._parameter_value == 'new_cases' %} ${pending_new}
@@ -239,8 +242,9 @@ view: covid_tracking_project_core {
 ## Based on new_vs_running_total parameter chosen, return new or running total positive test results
   measure: positive_test {
     group_label: "Dynamic (Testing - US Only)"
-    description: "Use with New vs Running Total Filter, can be useful for creating a Look or Dashboard where you toggle between the two"
+    description: "Use with New vs Running Total Filter, can be useful for creating a Look or Dashboard where you toggle between the two  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     label: "Positive Test Results"
+    hidden: yes
     type: number
     sql:
         {% if covid_combined.new_vs_running_total._parameter_value == 'new_cases' %} ${positive_new}
@@ -260,6 +264,7 @@ view: covid_tracking_project_core {
     description: "Use with New vs Running Total Filter, can be useful for creating a Look or Dashboard where you toggle between the two"
     label: "Total Tests"
     type: number
+    hidden: yes
     sql:
         {% if covid_combined.new_vs_running_total._parameter_value == 'new_cases' %} ${total_new}
         {% elsif covid_combined.new_vs_running_total._parameter_value == 'running_total' %} ${total_running_total}
@@ -276,6 +281,7 @@ view: covid_tracking_project_core {
     group_label: "New Cases (Testing - US Only)"
     description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used"
     label: "Hospitalizations"
+    hidden: yes
     type: sum
     sql: ${hospitalized_new_cases} ;;
     link: {
@@ -307,6 +313,7 @@ view: covid_tracking_project_core {
     label: "Hospitalizations (Running Total)"
     description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used."
     type: number
+    hidden: yes
     sql:
     {% if covid_combined.measurement_date._in_query %} ${hospitalized_option_1}
     {% else %}  ${hospitalized_option_2}
@@ -321,8 +328,9 @@ view: covid_tracking_project_core {
   measure: negative_new {
     group_label: "New Cases (Testing - US Only)"
     label: "Negative Test Results (New)"
-    description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used"
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     type: sum
+    hidden: yes
     sql: ${negative_new_cases} ;;
     link: {
       label: "Data Source - COVID Tracking Project"
@@ -352,7 +360,8 @@ view: covid_tracking_project_core {
     group_label: "Running Total (Testing - US Only)"
     label: "Negative Test Results (Running Total)"
     type: number
-    description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used."
+    hidden: yes
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used.  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     sql:
     {% if covid_combined.measurement_date._in_query %} ${negative_option_1}
     {% else %}  ${negative_option_2}
@@ -367,8 +376,9 @@ view: covid_tracking_project_core {
   measure: pending_new {
     group_label: "New Cases (Testing - US Only)"
     label: "Pending Test Results (New)"
-    description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used"
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     type: sum
+    hidden: yes
     sql: ${pending_new_cases} ;;
     link: {
       label: "Data Source - COVID Tracking Project"
@@ -397,8 +407,9 @@ view: covid_tracking_project_core {
   measure: pending_running_total {
     group_label: "Running Total (Testing - US Only)"
     label: "Pending Test Results (Running Total)"
-    description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used."
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used.  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     type: number
+    hidden: yes
     sql:
     {% if covid_combined.measurement_date._in_query %} ${pending_option_1}
     {% else %}  ${pending_option_2}
@@ -413,8 +424,9 @@ view: covid_tracking_project_core {
   measure: positive_new {
     group_label: "New Cases (Testing - US Only)"
     label: "Positive Test Results (New)"
-    description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used"
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     type: sum
+    hidden: yes
     sql: ${positive_new_cases} ;;
     link: {
       label: "Data Source - COVID Tracking Project"
@@ -442,9 +454,10 @@ view: covid_tracking_project_core {
 ## If date in query, show running total of positive test results for given date(s), otherwise show running total of positive test results for most recent dat
   measure: positive_running_total {
     group_label: "Running Total (Testing - US Only)"
-    description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used."
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used.  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     label: "Positive Test Results (Running Total)"
     type: number
+    hidden: yes
     sql:
     {% if covid_combined.measurement_date._in_query %} ${positive_option_1}
     {% else %}  ${positive_option_2}
@@ -459,8 +472,9 @@ view: covid_tracking_project_core {
   measure: total_new {
     group_label: "New Cases (Testing - US Only)"
     label: "Total Tests (New)"
-    description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used"
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used "
     type: sum
+    hidden: yes
     sql: ${total_new_cases} ;;
     link: {
       label: "Data Source - COVID Tracking Project"
@@ -491,6 +505,7 @@ view: covid_tracking_project_core {
     description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used."
     label: "Total Tests (Running Total)"
     type: number
+    hidden: yes
     sql:
     {% if covid_combined.measurement_date._in_query %} ${total_option_1}
     {% else %}  ${total_option_2}
@@ -504,8 +519,9 @@ view: covid_tracking_project_core {
 
   measure: positive_rate {
     group_label: "Rates (Testing - US Only)"
-    description: "Of all tests, how many are positive?"
+    description: "Of all tests, how many are positive?  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     type: number
+    hidden: yes
     sql: 1.0 * ${positive_running_total} / nullif((${total_running_total}),0);;
     value_format_name: percent_1
     link: {
@@ -517,8 +533,9 @@ view: covid_tracking_project_core {
 
   measure: pending_rate {
     group_label: "Rates (Testing - US Only)"
-    description: "Of all tests, how many are pending?"
+    description: "Of all tests, how many are pending?  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     type: number
+    hidden: yes
     sql: 1.0 * ${pending_running_total} / nullif((${total_running_total}),0);;
     value_format_name: percent_1
     link: {
@@ -530,8 +547,9 @@ view: covid_tracking_project_core {
 
   measure: negative_rate {
     group_label: "Rates (Testing - US Only)"
-    description: "Of all tests, how many are negative?"
+    description: "Of all tests, how many are negative?  **This field was deprecated on March 7 2021 by the Covid Tracking Project**"
     type: number
+    hidden: yes
     sql: 1.0 * ${negative_running_total} / nullif((${total_running_total}),0);;
     value_format_name: percent_1
     link: {
@@ -545,6 +563,7 @@ view: covid_tracking_project_core {
     group_label: "Rates (Testing - US Only)"
     description: "What percent of infections have resulted in hospitalization?"
     type: number
+    hidden: yes
     sql: 1.0 * ${hospitalized_running_total}/NULLIF(${positive_running_total}, 0);;
     value_format_name: percent_1
     link: {

--- a/covid_block/open_data_main.view.lkml
+++ b/covid_block/open_data_main.view.lkml
@@ -1,15 +1,16 @@
-# include: "//@{CONFIG_PROJECT_NAME}/covid_block/covid_tracking_project.view.lkml"
+include: "//@{CONFIG_PROJECT_NAME}/covid_block/open_data_main.view.lkml"
 
-#This data was brought in to show testing data from the COVID19 Tracing project - https://covidtracking.com/
+# open_data_main (New!) Pulls in data from the [COVID-19 Open Data project](https://github.com/GoogleCloudPlatform/covid-19-open-data)
+# and reports on testing, hospitalizations, and vaccination progress in the US.
 
-# view: covid_tracking_project {
-#   extends: [covid_tracking_project_config]
-# }
+view: open_data_main {
+  extends: [open_data_main_config]
+}
 
 ###################################################
 
 
-view: open_data_main {
+view: open_data_main_core {
   derived_table: {
     datagroup_trigger: covid_data
     cluster_keys: ["state_name"]
@@ -43,10 +44,6 @@ view: open_data_main {
         SELECT * FROM odm
         GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21 ;;
   }
-
-####################
-#### Original Dimensions ####
-####################
 
   dimension_group: measurement {
     hidden: yes
@@ -123,7 +120,7 @@ view: open_data_main {
       url: "https://github.com/GoogleCloudPlatform/covid-19-open-data"
     }
   }
-## If date in query, show running total of hospitalizations for given date(s), otherwise show running total hospitalizations for most recent date
+
   measure: hospitalized_running_total {
     group_label: "CDC Measures (US Only)"
     label: "Hospitalizations (Running Total)"
@@ -165,7 +162,6 @@ view: open_data_main {
     }
   }
 
-## If date in query, show running total of hospitalizations for given date(s), otherwise show running total hospitalizations for most recent date
   measure: cumulative_persons_vaccined_running_total {
     group_label: "CDC Measures (US Only)"
     label: "Persons Vaccinated (Running Total)"
@@ -207,7 +203,6 @@ view: open_data_main {
     }
   }
 
-## If date in query, show running total of hospitalizations for given date(s), otherwise show running total hospitalizations for most recent date
   measure: cumulative_persons_fully_vaccined_running_total {
     group_label: "CDC Measures (US Only)"
     label: "Persons Fully Vaccinated (Running Total)"
@@ -249,7 +244,6 @@ view: open_data_main {
     }
   }
 
-## If date in query, show running total of hospitalizations for given date(s), otherwise show running total hospitalizations for most recent date
   measure: cumulative_tested_running_total {
     group_label: "CDC Measures (US Only)"
     label: "Tests (Running Total)"
@@ -290,7 +284,6 @@ view: open_data_main {
     }
   }
 
-## If date in query, show running total of hospitalizations for given date(s), otherwise show running total hospitalizations for most recent date
   measure: cumulative_confirmed_running_total {
     group_label: "CDC Measures (US Only)"
     label: "Cumulative Confirmed (Running Total)"
@@ -321,7 +314,6 @@ view: open_data_main {
     }
   }
 
-## If date in query, show running total of hospitalizations for given date(s), otherwise show running total hospitalizations for most recent date
   measure: death_cumulative_running_total {
     group_label: "CDC Measures (US Only)"
     hidden: yes
@@ -363,21 +355,10 @@ view: open_data_main {
     }
   }
 
-
-####################
-#### Measures ####
-####################
-
   set: drill {
-    # fields: [
-    #   state,
-    #   measurement_date,
-    #   total,
-    #   positive_test,
-    #   pending_test,
-    #   negative_test,
-    #   deaths,
-    #   hospitalizations
-    # ]
+    fields: [
+      state_name,
+      measurement_date,
+    ]
   }
 }

--- a/covid_block/open_data_main.view.lkml
+++ b/covid_block/open_data_main.view.lkml
@@ -1,0 +1,383 @@
+# include: "//@{CONFIG_PROJECT_NAME}/covid_block/covid_tracking_project.view.lkml"
+
+#This data was brought in to show testing data from the COVID19 Tracing project - https://covidtracking.com/
+
+# view: covid_tracking_project {
+#   extends: [covid_tracking_project_config]
+# }
+
+###################################################
+
+
+view: open_data_main {
+  derived_table: {
+    datagroup_trigger: covid_data
+    cluster_keys: ["state_name"]
+    partition_keys: ["measurement_date"]
+    sql:
+      WITH odm AS (
+          SELECT
+            location_key,
+            SUBSTR(SPLIT(location_key, "US_")[OFFSET(1)],0,2) as state,
+            subregion1_name as state_name,
+            subregion2_name,
+            date as measurement_date,
+            new_confirmed,
+            cumulative_confirmed,
+            new_tested,
+            cumulative_tested,
+            cumulative_hospitalized_patients as hospitalized_cumulative,
+            new_hospitalized_patients,
+            current_hospitalized_patients,
+            new_ventilator_patients,
+            cumulative_ventilator_patients,
+            current_ventilator_patients,
+            new_persons_vaccinated,
+            cumulative_persons_vaccinated,
+            new_persons_fully_vaccinated,
+            cumulative_persons_fully_vaccinated,
+            new_vaccine_doses_administered,
+            cumulative_vaccine_doses_administered,
+          FROM `bigquery-public-data.covid19_open_data.covid19_open_data`
+          WHERE location_key LIKE 'US_%')
+        SELECT * FROM odm
+        GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21 ;;
+  }
+
+####################
+#### Original Dimensions ####
+####################
+
+  dimension_group: measurement {
+    hidden: yes
+    type: time
+    timeframes: [
+      raw,
+      date
+    ]
+    convert_tz: no
+    datatype: date
+    sql: parse_date('%Y-%m-%d',cast(${TABLE}.measurement_date as string));;
+  }
+
+  dimension: location_key {
+    hidden: yes
+    type: string
+    sql: ${TABLE}.location_key ;;
+  }
+
+  dimension: state_name {
+    hidden: yes
+    type: string
+    sql: ${TABLE}.state_name ;;
+  }
+
+  dimension: state_code {
+    hidden: yes
+    type: string
+    sql: ${TABLE}.state ;;
+  }
+
+  dimension: pk {
+    primary_key: yes
+    hidden: yes
+    type: string
+    sql: concat(${TABLE}.location_key, ${measurement_date}) ;;
+  }
+
+  measure: max_date {
+    hidden: yes
+    type: date
+    sql: max(${measurement_date}) ;;
+  }
+
+  dimension: is_max_date {
+    hidden: yes
+    type: yesno
+    sql: ${measurement_date} = ${max_date_tracking_project.max_date_raw} ;;
+  }
+
+  measure: hospitalized_option_1 {
+    hidden: yes
+    type: sum
+    sql: ${TABLE}.hospitalized_cumulative ;;
+  }
+
+  measure: hospitalized_option_2 {
+    hidden: yes
+    type: sum
+    sql: ${TABLE}.current_hospitalized_patients ;;
+    filters: {
+      field: is_max_date
+      value: "Yes"
+    }
+  }
+  measure: new_persons_hospitalized {
+    group_label: "CDC Measures (US Only)"
+    label: "Hospitalizations (New)"
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used"
+    type: sum
+    sql: ${TABLE}.new_hospitalized_patients ;;
+    link: {
+      label: "Data Source - COVID19 Open Data"
+      url: "https://github.com/GoogleCloudPlatform/covid-19-open-data"
+    }
+  }
+## If date in query, show running total of hospitalizations for given date(s), otherwise show running total hospitalizations for most recent date
+  measure: hospitalized_running_total {
+    group_label: "CDC Measures (US Only)"
+    label: "Hospitalizations (Running Total)"
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used."
+    type: number
+    sql:
+    {% if covid_combined.measurement_date._in_query %} ${hospitalized_option_1}
+    {% else %}  ${hospitalized_option_2}
+    {% endif %} ;;
+    link: {
+      label: "Data Source - COVID19 Open Data"
+      url: "https://github.com/GoogleCloudPlatform/covid-19-open-data"
+    }
+  }
+  measure: new_persons_vaccinated {
+    group_label: "CDC Measures (US Only)"
+    label: "Persons Vaccinated (New)"
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used"
+    type: sum
+    sql: ${TABLE}.new_persons_vaccinated ;;
+    link: {
+      label: "Data Source - COVID19 Open Data"
+      url: "https://github.com/GoogleCloudPlatform/covid-19-open-data"
+    }
+  }
+  measure: cumulative_persons_vaccinated_option_1 {
+    hidden: yes
+    type: sum
+    sql: ${TABLE}.cumulative_persons_vaccinated ;;
+  }
+
+  measure: cumulative_persons_vaccinated_option_2 {
+    hidden: yes
+    type: min
+    sql: ${TABLE}.cumulative_persons_vaccinated ;;
+    filters: {
+      field: is_max_date
+      value: "Yes"
+    }
+  }
+
+## If date in query, show running total of hospitalizations for given date(s), otherwise show running total hospitalizations for most recent date
+  measure: cumulative_persons_vaccined_running_total {
+    group_label: "CDC Measures (US Only)"
+    label: "Persons Vaccinated (Running Total)"
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used."
+    type: number
+    sql:
+    {% if covid_combined.measurement_date._in_query %} ${cumulative_persons_vaccinated_option_1}
+    {% else %}  ${cumulative_persons_vaccinated_option_2}
+    {% endif %} ;;
+    link: {
+      label: "Data Source - COVID19 Open Data"
+      url: "https://github.com/GoogleCloudPlatform/covid-19-open-data"
+    }
+  }
+  measure: new_persons_fully_vaccinated {
+    group_label: "CDC Measures (US Only)"
+    label: "Persons Fully Vaccinated (New)"
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used"
+    type: sum
+    sql: ${TABLE}.new_persons_fully_vaccinated ;;
+    link: {
+      label: "Data Source - COVID19 Open Data"
+      url: "https://github.com/GoogleCloudPlatform/covid-19-open-data"
+    }
+  }
+  measure: cumulative_persons_fully_vaccinated_option_1 {
+    hidden: yes
+    type: sum
+    sql: ${TABLE}.cumulative_persons_fully_vaccinated ;;
+  }
+
+  measure: cumulative_persons_fully_vaccinated_option_2 {
+    hidden: yes
+    type: min
+    sql: ${TABLE}.cumulative_persons_fully_vaccinated ;;
+    filters: {
+      field: is_max_date
+      value: "Yes"
+    }
+  }
+
+## If date in query, show running total of hospitalizations for given date(s), otherwise show running total hospitalizations for most recent date
+  measure: cumulative_persons_fully_vaccined_running_total {
+    group_label: "CDC Measures (US Only)"
+    label: "Persons Fully Vaccinated (Running Total)"
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used."
+    type: number
+    sql:
+    {% if covid_combined.measurement_date._in_query %} ${cumulative_persons_fully_vaccinated_option_1}
+    {% else %}  ${cumulative_persons_fully_vaccinated_option_2}
+    {% endif %} ;;
+    link: {
+      label: "Data Source - COVID19 Open Data"
+      url: "https://github.com/GoogleCloudPlatform/covid-19-open-data"
+    }
+  }
+  measure: tests_new {
+    group_label: "CDC Measures (US Only)"
+    label: "Tests (New)"
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used"
+    type: sum
+    sql: ${TABLE}.new_tested ;;
+    link: {
+      label: "Data Source - COVID19 Open Data"
+      url: "https://github.com/GoogleCloudPlatform/covid-19-open-data"
+    }
+  }
+  measure: cumulative_tested_option_1 {
+    hidden: yes
+    type: sum
+    sql: ${TABLE}.cumulative_tested ;;
+  }
+
+  measure: cumulative_tested_option_2 {
+    hidden: yes
+    type: min
+    sql: ${TABLE}.cumulative_tested ;;
+    filters: {
+      field: is_max_date
+      value: "Yes"
+    }
+  }
+
+## If date in query, show running total of hospitalizations for given date(s), otherwise show running total hospitalizations for most recent date
+  measure: cumulative_tested_running_total {
+    group_label: "CDC Measures (US Only)"
+    label: "Tests (Running Total)"
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used."
+    type: number
+    sql:
+    {% if covid_combined.measurement_date._in_query %} ${cumulative_tested_option_1}
+    {% else %}  ${cumulative_tested_option_2}
+    {% endif %} ;;
+    link: {
+      label: "Data Source - CDC"
+    }
+  }
+  measure: confirmed_new {
+    group_label: "CDC Measures (US Only)"
+    label: "Confirmed Cases (New)"
+    hidden: yes
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the new cases during the selected timeframe, otherwise the most recent record will be used"
+    type: sum
+    sql: ${TABLE}.new_confirmed ;;
+    link: {
+      label: "Data Source - CDC"
+    }
+  }
+  measure: cumulative_confirmed_option_1 {
+    hidden: yes
+    type: sum
+    sql: ${TABLE}.cumulative_confirmed ;;
+  }
+
+  measure: cumulative_confirmed_option_2 {
+    hidden: yes
+    type: min
+    sql: ${TABLE}.cumulative_confirmed ;;
+    filters: {
+      field: is_max_date
+      value: "Yes"
+    }
+  }
+
+## If date in query, show running total of hospitalizations for given date(s), otherwise show running total hospitalizations for most recent date
+  measure: cumulative_confirmed_running_total {
+    group_label: "CDC Measures (US Only)"
+    label: "Cumulative Confirmed (Running Total)"
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used."
+    type: number
+    hidden: yes
+    sql:
+    {% if covid_combined.measurement_date._in_query %} ${cumulative_confirmed_option_1}
+    {% else %}  ${cumulative_confirmed_option_2}
+    {% endif %} ;;
+    link: {
+      label: "Data Source - CDC"
+    }
+  }
+  measure: death_cumulative_option_1 {
+    hidden: yes
+    type: min
+    sql: ${TABLE}.cumulative_tested ;;
+  }
+
+  measure: death_cumulative_option_2 {
+    hidden: yes
+    type: min
+    sql: ${TABLE}.cumulative_tested ;;
+    filters: {
+      field: is_max_date
+      value: "Yes"
+    }
+  }
+
+## If date in query, show running total of hospitalizations for given date(s), otherwise show running total hospitalizations for most recent date
+  measure: death_cumulative_running_total {
+    group_label: "CDC Measures (US Only)"
+    hidden: yes
+    label: "Death Cumulative (Running Total)"
+    description: "Filter on Measurement Date or Days Since First Outbreak to see the running total on a specific date, don't use with a range of dates or else the results will show the sum of the running totals for each day in that timeframe. If no dates are selected the most recent record will be used."
+    type: number
+    sql:
+    {% if covid_combined.measurement_date._in_query %} ${death_cumulative_option_1}
+    {% else %}  ${death_cumulative_option_2}
+    {% endif %} ;;
+    link: {
+      label: "Data Source - COVID19 Open Data"
+      url: "https://github.com/GoogleCloudPlatform/covid-19-open-data"
+    }
+  }
+  measure: positive_rate {
+    group_label: "CDC Measures (US Only)"
+    description: "Of all tests, how many are positive?"
+    type: number
+    hidden: no
+    sql: 1.0 * ${cumulative_confirmed_running_total} / nullif((${cumulative_tested_running_total}),0);;
+    value_format_name: percent_1
+    link: {
+      label: "Data Source - COVID19 Open Data"
+      url: "https://github.com/GoogleCloudPlatform/covid-19-open-data"
+    }
+  }
+
+  measure: case_hospitalization_rate {
+    group_label: "CDC Measures (US Only)"
+    description: "What percent of infections have resulted in hospitalization?"
+    type: number
+    hidden: no
+    sql: 1.0 * ${hospitalized_running_total}/NULLIF(${cumulative_confirmed_running_total}, 0);;
+    value_format_name: percent_1
+    link: {
+      label: "Data Source - COVID19 Open Data"
+      url: "https://github.com/GoogleCloudPlatform/covid-19-open-data"
+    }
+  }
+
+
+####################
+#### Measures ####
+####################
+
+  set: drill {
+    # fields: [
+    #   state,
+    #   measurement_date,
+    #   total,
+    #   positive_test,
+    #   pending_test,
+    #   negative_test,
+    #   deaths,
+    #   hospitalizations
+    # ]
+  }
+}

--- a/covid_block/open_data_main.view.lkml
+++ b/covid_block/open_data_main.view.lkml
@@ -154,7 +154,7 @@ view: open_data_main_core {
 
   measure: cumulative_persons_vaccinated_option_2 {
     hidden: yes
-    type: min
+    type: sum
     sql: ${TABLE}.cumulative_persons_vaccinated ;;
     filters: {
       field: is_max_date
@@ -195,7 +195,7 @@ view: open_data_main_core {
 
   measure: cumulative_persons_fully_vaccinated_option_2 {
     hidden: yes
-    type: min
+    type: sum
     sql: ${TABLE}.cumulative_persons_fully_vaccinated ;;
     filters: {
       field: is_max_date
@@ -236,7 +236,7 @@ view: open_data_main_core {
 
   measure: cumulative_tested_option_2 {
     hidden: yes
-    type: min
+    type: sum
     sql: ${TABLE}.cumulative_tested ;;
     filters: {
       field: is_max_date
@@ -276,7 +276,7 @@ view: open_data_main_core {
 
   measure: cumulative_confirmed_option_2 {
     hidden: yes
-    type: min
+    type: sum
     sql: ${TABLE}.cumulative_confirmed ;;
     filters: {
       field: is_max_date
@@ -300,13 +300,13 @@ view: open_data_main_core {
   }
   measure: death_cumulative_option_1 {
     hidden: yes
-    type: min
+    type: sum
     sql: ${TABLE}.cumulative_tested ;;
   }
 
   measure: death_cumulative_option_2 {
     hidden: yes
-    type: min
+    type: sum
     sql: ${TABLE}.cumulative_tested ;;
     filters: {
       field: is_max_date

--- a/explores/covid_combined.explore.lkml
+++ b/explores/covid_combined.explore.lkml
@@ -16,12 +16,18 @@ explore: covid_combined_core {
     sql_on: ${covid_combined.province_state} = ${state_region.state} ;;
   }
 
+  join: open_data_main {
+    view_label: " COVID19"
+    relationship: many_to_many
+    sql_on: ${state_region.state} = ${open_data_main.state_name}
+    AND ${covid_combined.measurement_date} = ${open_data_main.measurement_date} ;;
+  }
+
   join: covid_tracking_project {
     view_label: " COVID19"
     relationship: many_to_one
-    sql_on:
-          ${state_region.state_code} = ${covid_tracking_project.state_code}
-      AND ${covid_combined.measurement_raw} = ${covid_tracking_project.measurement_raw}
+    sql_on:${state_region.state_code} = ${covid_tracking_project.state_code}
+            AND ${covid_combined.measurement_raw} = ${covid_tracking_project.measurement_raw}
     ;;
   }
 

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,9 @@
 
 ##### *Views that pull data from datasets we've made available in BigQuery - the ETL for these has not been fully tested, and data should be treated with somewhat less certainty:*
 
-• [covid_tracking_project](/projects/covid/files/covid_block/covid_tracking_project.view.lkml) Pulls in data from the [COVID-19 Tracking project](https://github.com/COVID19Tracking/covid-tracking-data/blob/master/data/states_daily_4pm_et.csv  ) and houses calculations on testing in the US
+• [covid_tracking_project](/projects/covid/files/covid_block/covid_tracking_project.view.lkml) Pulls in data from the [COVID-19 Tracking project](https://github.com/COVID19Tracking/covid-tracking-data/blob/master/data/states_daily_4pm_et.csv  ) and houses calculations on testing in the US. ** The Covid Tracking Project stopped reporting updates on March 7, 2021. Similiar measures were introduced with open_data_main.**
+
+• [open_data_main](/projects/covid/files/covid_block/open_data_main.view.lkml) (New!) Pulls in data from the [COVID-19 Open Data project](https://github.com/GoogleCloudPlatform/covid-19-open-data) and reports on testing, hospitalizations, and vaccination progress in the US.
 
 • [policies_by_state](/projects/covid/files/covid_block/policies_by_state.view.lkml) Pulls in data from the [Kaiser Family Foundation](https://s3-us-west-1.amazonaws.com/starschema.covid/) on policies that states have implemented in response to COVID-19
 


### PR DESCRIPTION
On March 7 2021 the Covid Tracking Project stopped reporting some measures with the plan of fully shutting down in early May. This PR brings in the Covid 19 Open Data source from the BQ Datasets team. This data comes from the CDC and includes vaccination progress. https://github.com/GoogleCloudPlatform/covid-19-open-data

The CTP measures under various Group Labels were reduced to a new group label "CDC Measures (US Only)"

Once merged I'll stage PR to update the Config project.

This PR does not add dashboarding, perhaps we can add a tile or two to the US dashboard for vaccines?


